### PR TITLE
fix: add undeclared dependency `lodash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "scss-parser",
       "version": "1.0.5",
       "license": "SEE LICENSE IN README",
       "dependencies": {
         "invariant": "2.2.4",
-        "lodash": "^4.17.21"
+        "lodash": "4.17.21"
       },
       "devDependencies": {
         "jest": "^24.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "version": "1.0.5",
       "license": "SEE LICENSE IN README",
       "dependencies": {
-        "invariant": "2.2.4"
+        "invariant": "2.2.4",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "jest": "^24.9.0",
@@ -4473,8 +4474,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -10818,8 +10818,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "invariant": "2.2.4",
-    "lodash": "^4.17.21"
+    "lodash": "4.17.21"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "standard"
   },
   "dependencies": {
-    "invariant": "2.2.4"
+    "invariant": "2.2.4",
+    "lodash": "^4.17.21"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
**What's the problem this PR addresses?**

`scss-parser` depends on `lodash` but doesn't declare it as a dependency

**How did you fix it?**

Added `lodash` as a dependency